### PR TITLE
Fix slow "join game" page

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "hanabi-df790"
+  }
+}

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    ".read": true,
+    ".write": true,
+
+    "games": {
+      ".indexOn": ["createdAt"]
+    }
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "database": {
+    "rules": "database.rules.json"
+  }
+}

--- a/hooks/firebase.ts
+++ b/hooks/firebase.ts
@@ -32,6 +32,15 @@ export function setupFirebase() {
   return firebase.database();
 }
 
+function gameIsPublic(game: IGameState) {
+  return (
+    !game.options.private &&
+    game.status === IGameStatus.LOBBY &&
+    game.players.length &&
+    game.players.length < game.playersCount
+  );
+}
+
 export default class FirebaseNetwork implements Network {
   db: firebase.database.Database;
 
@@ -40,21 +49,16 @@ export default class FirebaseNetwork implements Network {
   }
 
   subscribeToPublicGames(callback: GamesHandler) {
-    const ref = this.db.ref("/games");
+    const ref = this.db
+      .ref("/games")
+      // Only games created less than 10 minutes ago
+      .orderByChild("createdAt")
+      .startAt(Date.now() - 10 * 60 * 1000);
 
     ref.on("value", event => {
       const games = Object.values(event.val() || {})
         .map(fillEmptyValues)
-        // Game is public
-        .filter(game => !game.options.private)
-        // Game is in lobby state
-        .filter(game => game.status === IGameStatus.LOBBY)
-        // At least one player in the room
-        .filter(game => game.players.length)
-        // There are slots remaining
-        .filter(game => +game.players.length < +game.playersCount)
-        // The game is recent
-        .filter(game => game.createdAt > Date.now() - 10 * 60 * 1000);
+        .filter(gameIsPublic);
 
       callback(games);
     });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "server": "firebase-server -p 3001",
     "lint": "eslint '**/*.{ts,tsx}'",
-    "test": "cypress run"
+    "test": "cypress run",
+    "deploy-database": "firebase deploy --only database"
   },
   "dependencies": {
     "@types/classnames": "^2.2.9",


### PR DESCRIPTION
Indexes the `games.createdAt` field and orders/limit games when during subscription.

Not sure whether we should commit `.firebaserc`. Doing it for now since I can't find a good alternative using env vars. (https://firebase.google.com/docs/cli/#project_aliases)

Also might be useful to run `yarn deploy-database` automatically when deploying to production. Can now do that?