### PR TITLE
Notify players when it's their turn

### DIFF
--- a/components/lobby.tsx
+++ b/components/lobby.tsx
@@ -28,7 +28,7 @@ export default function Lobby(props: Props) {
 
   const router = useRouter();
   const [name, setName] = useState(generateName().dashed);
-  const [bot, setBot] = useState(false);
+  const [bot] = useState(false);
 
   const shareLink = `${window.location.origin}/play?gameId=${router.query.gameId}`;
   const inputRef = React.createRef<HTMLInputElement>();

--- a/pages/play.tsx
+++ b/pages/play.tsx
@@ -145,16 +145,7 @@ export default function Play() {
         }
       };
     } catch (e) {
-      // If it fails for mobile devices, send it through a service worker.
-      navigator.serviceWorker.getRegistrations().then(function(registrations) {
-        if (!registrations.length) return;
-
-        registrations[0].showNotification(title, {
-          ...options,
-          requireInteraction: true,
-          vibrate: [200, 100, 200, 100, 200, 100, 200]
-        });
-      });
+      // Not handled for many mobile browsers.
     }
   }, [currentPlayer === selfPlayer]);
 


### PR DESCRIPTION
## Done

- Chrome will request notification permissions when the game starts
- Players will receive a "Your turn!" notification when it's their turn and their tab is not focused.
- Web: the notification fades after 20s or when the user clicks on it (which refocused the tab)
- Mobile: the notification has zero interaction yet. Web mobile API are pretty hard 🙄 

## OST

- Register own SW and send everything through it (also we need a fallback for HTTP) - https://stackoverflow.com/questions/33859969/calling-javascript-notification-api-on-google-chrome-for-android-not-working-dir/34132295#34132295
- Show latest turn if any in notification body - Need to write a custom function since the current one returns a React component and not a string
- Check pass & play

![image](https://user-images.githubusercontent.com/1478542/74269891-8daa9580-4d0a-11ea-9275-35c8f610cf0c.png)

![Screenshot_20200211-201247](https://user-images.githubusercontent.com/1478542/74270368-656f6680-4d0b-11ea-9ec9-099f58c8b6c0.jpg)

![Screenshot_20200211-203646](https://user-images.githubusercontent.com/1478542/74272082-4e7e4380-4d0e-11ea-888b-53e1420e3398.jpg)
