### PR TITLE
add GA

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "rc-slider": "^9.2.1",
     "react": "16.8.6",
     "react-dom": "16.8.6",
+    "react-ga": "^2.7.0",
     "react-modal": "^3.9.1",
     "react-popover": "^0.5.10",
     "react-pose": "^4.0.8",

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,23 @@
+import ReactGA from "react-ga";
+
+export const initGA = () => {
+  if (process.env.NODE_ENV === "production") {
+    ReactGA.initialize("UA-56583082-2");
+  }
+};
+
+export const logPageView = () => {
+  ReactGA.set({ page: window.location.pathname });
+  ReactGA.pageview(window.location.pathname);
+};
+
+export const logEvent = (category: string, action: string) => {
+  if (category && action) {
+    ReactGA.event({ category, action });
+  }
+};
+export const logException = (description: string, fatal = false) => {
+  if (description) {
+    ReactGA.exception({ description, fatal });
+  }
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,9 @@
 import "../styles/style.css";
 
 import * as Sentry from "@sentry/browser";
-import NextApp from "next/app";
+import NextApp, { AppProps } from "next/app";
 import Head from "next/head";
+import Router from "next/router";
 import React, { ErrorInfo, useState } from "react";
 
 import Txt, { TxtSize } from "~/components/ui/txt";
@@ -10,12 +11,20 @@ import useConnectivity from "~/hooks/connectivity";
 import FirebaseNetwork, { setupFirebase } from "~/hooks/firebase";
 import { NetworkContext } from "~/hooks/network";
 
+import { initGA, logPageView } from "../lib/analytics";
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV
 });
 
+Router.events.on("routeChangeComplete", () => logPageView());
+
 export default class App extends NextApp {
+  componentDidMount() {
+    initGA();
+  }
+
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     Sentry.withScope(scope => {
       Object.keys(errorInfo).forEach(key => {
@@ -29,11 +38,11 @@ export default class App extends NextApp {
   }
 
   render() {
-    return <Hanabi Component={this.props.Component} />;
+    return <Hanabi {...this.props} />;
   }
 }
 
-function Hanabi(props: any) {
+function Hanabi(props: AppProps) {
   const { Component } = props;
 
   const [showOffline, setShowOffline] = useState(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6684,6 +6684,11 @@ react-error-overlay@5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
 
+react-ga@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.7.0.tgz#24328f157f31e8cffbf4de74a3396536679d8d7c"
+  integrity sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==
+
 react-is@16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"


### PR DESCRIPTION
fixes #62

Right now, only tracks page views. We could add the following events:
- When a game is started (send the number of players/AI, game settings)
- When a game is finished (send the number of playesr/AI, score, game settings)

Those can also be derived from the firebase store but it's perhaps easier to see it from GA?