### PR TITLE
Fix "restart game"

### DIFF
--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -395,13 +395,8 @@ export function Game(props: Props) {
   async function onRestartGame() {
     const nextGame = recreateGame(game);
 
-    await updateGame({
-      ...game,
-      nextGameId: nextGame.id,
-    });
-
-    // synced: true seems to be necessary to get the AI to play once the new game starts
-    onGameChange({ ...nextGame, synced: true });
+    await updateGame(nextGame);
+    onGameChange(nextGame);
 
     logEvent("Game", "Game recreated");
     router.push(`/${nextGame.id}`);

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -395,14 +395,17 @@ export function Game(props: Props) {
   async function onRestartGame() {
     const nextGame = recreateGame(game);
 
-    await updateGame(nextGame);
-
-    updateGame({
+    await updateGame({
       ...game,
       nextGameId: nextGame.id,
     });
 
+    // synced: true seems to be necessary to get the AI to play once the new game starts
+    onGameChange({ ...nextGame, synced: true });
+
     logEvent("Game", "Game recreated");
+    router.push(`/${nextGame.id}`);
+
   }
 
   return (

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -464,6 +464,10 @@ export function recreateGame(game: IGameState) {
     seed: `${Math.round(Math.random() * 10000)}`,
   });
 
+  // Player index matters for whether a bot can play. 
+  // If there's only one non-bot player, they must have index 0 or the bots won't play
+  // TODO sort so that bots are last
+  // OR, remove the player index check in the "Play for bots." effect
   shuffle(game.players).forEach(player => {
     nextGame = joinGame(nextGame, player);
   });

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -464,10 +464,6 @@ export function recreateGame(game: IGameState) {
     seed: `${Math.round(Math.random() * 10000)}`,
   });
 
-  // Player index matters for whether a bot can play. 
-  // If there's only one non-bot player, they must have index 0 or the bots won't play
-  // TODO sort so that bots are last
-  // OR, remove the player index check in the "Play for bots." effect
   shuffle(game.players).forEach(player => {
     nextGame = joinGame(nextGame, player);
   });

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -458,11 +458,9 @@ export function newGame(options: IGameOptions): IGameState {
 }
 
 export function recreateGame(game: IGameState) {
-  const nextGameId = readableUniqueId();
-
   let nextGame = newGame({
     ...game.options,
-    id: nextGameId,
+    id: game.nextGameId || readableUniqueId(),
     seed: `${Math.round(Math.random() * 10000)}`,
   });
 

--- a/src/pages/[gameId]/index.tsx
+++ b/src/pages/[gameId]/index.tsx
@@ -56,7 +56,7 @@ export default function Play(props: Props) {
 
       setGame({ ...game, synced: true });
     });
-  }, [online]);
+  }, [online, game.id]);
 
   return (
     <TutorialProvider>


### PR DESCRIPTION
Addresses https://github.com/bstnfrmry/hanabi/issues/219

Previously, clicking on the "New Game" button after completing a game doesn't start the new game, and players have to manually reload the page. 


This attempts to fix it by:
- In the top-level game state effect, re-subscribing to the game state when the game id changes. 
- Calling `onGameChange` with the updated game, so that the local state gets updated. 
- Navigating to the new game. 

However, in testing locally i came across another bug that also shows up in production: the AI does not start playing until the page is reloaded. It looks like it gets stuck because [`selfPlayer.index` is `1`, when I think it should be `0`](https://github.com/bstnfrmry/hanabi/blob/ae24cba63667efa4d75272920d2af2e88cd67588/src/components/game.tsx#L88).

Any pointers or guidance on this other bug would be appreciated, but I'd ask that it not block fixing the "restart game" bug. 