### PR TITLE
Dangerous card calculation and display fix for critical rainbow

### DIFF
--- a/src/components/gameStats.tsx
+++ b/src/components/gameStats.tsx
@@ -7,10 +7,8 @@ import Txt, { TxtSize } from "~/components/ui/txt";
 import { useGame } from "~/hooks/game";
 import useLongPress from "~/hooks/longPress";
 import { getStateAtTurn, isPlayable } from "~/lib/actions";
-import { isCardDangerous } from "~/lib/ai";
+import { isCardDangerous, isCardEverPlayable } from "~/lib/ai";
 import IGameState, { fillEmptyValues, ICard, IColor, IInsightColor, IPlayer, ITurn } from "~/lib/state";
-
-const CountPerNumber = { 1: 3, 2: 2, 3: 2, 4: 2, 5: 1 };
 
 function turnToStateColor(turn: ITurn) {
   const { action } = turn.action;
@@ -35,23 +33,7 @@ function cardToStateColor(game: IGameState, player: IPlayer, card: ICard) {
     return [IInsightColor.Dangerous];
   }
 
-  const playedCard = game.playedCards.find((c) => card.number === c.number && card.color === c.color);
-  if (playedCard) {
-    return [IInsightColor.Discard];
-  }
-
-  const discardedCardsOfSameColorAndInferiorValue = game.discardPile.filter(
-    (c) => card.number < c.number && card.color === c.color
-  );
-
-  if (card.color === IColor.MULTICOLOR && discardedCardsOfSameColorAndInferiorValue.length) {
-    return [IInsightColor.Discard];
-  }
-  const groupedByNumber = groupBy(discardedCardsOfSameColorAndInferiorValue, (card) => card.number);
-  const allCardsInDiscard = Object.keys(groupedByNumber).find((number) => {
-    return groupedByNumber[number].length === CountPerNumber[number];
-  });
-  if (allCardsInDiscard) {
+  if (!isCardEverPlayable(card, game)) {
     return [IInsightColor.Discard];
   }
 

--- a/src/lib/ai-cheater.ts
+++ b/src/lib/ai-cheater.ts
@@ -1,5 +1,6 @@
 import { last, sortBy } from "lodash";
 import { commitAction, MaxHints } from "~/lib/actions";
+import { isCriticalCard, isCardDangerous, isCardEverPlayable } from "~/lib/ai";
 import IGameState, { ICard, IColor } from "~/lib/state";
 
 function canPlay(game: IGameState, card: ICard) {
@@ -12,14 +13,12 @@ function canPlay(game: IGameState, card: ICard) {
   return card.number === 1;
 }
 
-const AmountPerColor = { 1: 3, 2: 2, 3: 2, 4: 2, 5: 1 };
-
 function cardIdentity(cardA, cardB) {
   return cardA.color === cardB.color && cardA.number === cardB.number;
 }
 
 function canSafelyDiscard(game: IGameState, card: ICard) {
-  if (card.color === IColor.MULTICOLOR) return false;
+  if (isCriticalCard(card, game) && isCardEverPlayable(card, game)) return false;
 
   if (game.playedCards.find((playedCard) => cardIdentity(card, playedCard))) {
     return true;
@@ -29,15 +28,8 @@ function canSafelyDiscard(game: IGameState, card: ICard) {
 }
 
 function canDiscard(game: IGameState, card: ICard) {
-  if (card.color === IColor.MULTICOLOR) return false;
-
-  if (game.playedCards.find((playedCard) => cardIdentity(card, playedCard))) {
-    return true;
-  }
-
-  const identicalDiscardedCards = game.discardPile.filter((discardedCard) => cardIdentity(card, discardedCard));
-
-  return identicalDiscardedCards.length < AmountPerColor[card.number] - 1;
+  if (isCriticalCard(card, game) && isCardEverPlayable(card, game)) return false;
+  return !isCardDangerous(card, game);
 }
 
 export function cheat(game: IGameState): IGameState {
@@ -47,7 +39,7 @@ export function cheat(game: IGameState): IGameState {
   const playableCards = currentPlayer.hand.filter((card) => canPlay(game, card));
   const [playableCard] = sortBy(
     sortBy(playableCards, (card) => card.number),
-    (card) => card.color === IColor.MULTICOLOR
+    (card) => isCriticalCard(card, game)
   );
   if (playableCard) {
     return commitAction(game, {


### PR DESCRIPTION
This pull request is addressing the #234 issue, I have created.
Contains the following changes:
- added logic for identifying critical cards and generalizing card count calculation
- removed duplicate logic by exporting and using `isCardEverPlayable`
- applied the `isCardEverPlayable` for identifying discardable cards