### PR TITLE
Adapting AI for rainbow - improvement

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -84,16 +84,22 @@ function applyHint(hand: IHand, hint: IHintAction, game: IGameState) {
 
     // if there's only one possible color, make it sure
     const onlyPossibleColors = Object.keys(card.hint.color).filter(
-      (color) => card.hint.color[color] === IHintLevel.POSSIBLE
+      (color) => card.hint.color[color] > IHintLevel.IMPOSSIBLE
     );
+    if (onlyPossibleColors.length === 2) {
+      onlyPossibleColors.forEach((possibleColor) => card.hint.color[possibleColor] = IHintLevel.CANDIDATE)
+    }
     if (onlyPossibleColors.length === 1) {
       card.hint.color[onlyPossibleColors[0]] = IHintLevel.SURE;
     }
 
     // if there's only one possible number, make it sure
     const onlyPossibleNumbers = Object.keys(card.hint.number).filter(
-      (number) => card.hint.number[number] === IHintLevel.POSSIBLE
+      (number) => card.hint.number[number] > IHintLevel.IMPOSSIBLE
     );
+    if (onlyPossibleNumbers.length === 2) {
+      onlyPossibleNumbers.forEach((possibleNumber) => card.hint.number[possibleNumber] = IHintLevel.CANDIDATE)
+    }
     if (onlyPossibleNumbers.length === 1) {
       card.hint.number[onlyPossibleNumbers[0]] = IHintLevel.SURE;
     }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -82,24 +82,26 @@ function applyHint(hand: IHand, hint: IHintAction, game: IGameState) {
       }
     }
 
-    // if there's only one possible color, make it sure
     const onlyPossibleColors = Object.keys(card.hint.color).filter(
       (color) => card.hint.color[color] > IHintLevel.IMPOSSIBLE
     );
+    // if there's only two possible color, make it considered as a candidate for being that color
     if (onlyPossibleColors.length === 2) {
       onlyPossibleColors.forEach((possibleColor) => card.hint.color[possibleColor] = IHintLevel.CANDIDATE)
     }
+    // if there's only one possible color, make it sure
     if (onlyPossibleColors.length === 1) {
       card.hint.color[onlyPossibleColors[0]] = IHintLevel.SURE;
     }
 
-    // if there's only one possible number, make it sure
     const onlyPossibleNumbers = Object.keys(card.hint.number).filter(
       (number) => card.hint.number[number] > IHintLevel.IMPOSSIBLE
     );
+    // if there's only two possible number, make it considered as a candidate for being that number
     if (onlyPossibleNumbers.length === 2) {
       onlyPossibleNumbers.forEach((possibleNumber) => card.hint.number[possibleNumber] = IHintLevel.CANDIDATE)
     }
+    // if there's only one possible number, make it sure
     if (onlyPossibleNumbers.length === 1) {
       card.hint.number[onlyPossibleNumbers[0]] = IHintLevel.SURE;
     }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -103,7 +103,8 @@ export type INumber = 1 | 2 | 3 | 4 | 5;
 export enum IHintLevel {
   IMPOSSIBLE = 0,
   POSSIBLE = 1,
-  SURE = 2,
+  CANDIDATE = 2,
+  SURE = 3,
 }
 
 // an array of 2 (direct hint), 1 (still possible), or 0 (impossible)


### PR DESCRIPTION
This PR adresses the #107 - Adapt AI for Rainbow Variant issue.
This PR also incorporates another PR's content, see https://github.com/bstnfrmry/hanabi/pull/236 and #234 . Since the branch is not yet created in the origin, I could not create the PR to see only the diff between these.
Important modifications
- Introduces a new level of `IHintLevel`:`CANDIDATE` which shows if a color hint has been given, but it can be the hinted color or rainbow. With negative hints the number hint can reach this level too, which enables a more fine grained AI logic as well.
- isDiscardableCard has been modified so that it considers IHiddenCards possibly as dangerous, hopefully it improves also the success rate of AIs 
- finding the possible hint switches the hint if it would have been a "rainbow color hint" 