### PR TITLE
Preserve selection state after bell is clicked (fixes #163)

### DIFF
--- a/src/components/playersBoard.tsx
+++ b/src/components/playersBoard.tsx
@@ -34,11 +34,11 @@ export default function PlayersBoard(props: Props) {
   let selectedPlayer = null;
   let cardIndex = null;
   if (selectedArea.type === ActionAreaType.SELF_PLAYER) {
-    selectedPlayer = selectedArea.player;
+    selectedPlayer = game.players.find((player) => player.id === selectedArea.player.id);
     cardIndex = selectedArea.cardIndex;
   }
   if (selectedArea.type === ActionAreaType.OTHER_PLAYER) {
-    selectedPlayer = selectedArea.player;
+    selectedPlayer = game.players.find((player) => player.id === selectedArea.player.id);
   }
 
   return (


### PR DESCRIPTION
Whenever the game state changes (e.g. after the bell is clicked), the clientside `IGameState` is recreated from scratch, but the `selectedArea` state holds a reference to a stale `IPlayer` instance from a previous `IGameState`. The player board component uses an object identity comparison to determine which player was selected, and this comparison would return `false` when comparing objects from different `IGameState`s. As a result, it would incorrectly conclude that no players were selected, which would interrupt the selection in the UI.

Fixes #163