### PR TITLE
Allow more than 10000 unique shuffles

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { cloneDeep, findIndex, flatMap, last, range, shuffle, zipObject } from "lodash";
 import mem from "mem";
 import { shuffle as shuffleSeed } from "shuffle-seed";
-import { readableUniqueId } from "./id";
+import { generateShuffleSeed, readableUniqueId } from "./id";
 import IGameState, {
   GameVariant,
   IAction,
@@ -460,7 +460,7 @@ export function recreateGame(game: IGameState) {
   let nextGame = newGame({
     ...game.options,
     id: game.nextGameId || readableUniqueId(),
-    seed: `${Math.round(Math.random() * 10000)}`,
+    seed: generateShuffleSeed(),
   });
 
   shuffle(game.players).forEach((player) => {

--- a/src/lib/id.ts
+++ b/src/lib/id.ts
@@ -15,3 +15,9 @@ export function readableUniqueId(): ID {
 export function uniqueId(): ID {
   return shortid();
 }
+
+export function generateShuffleSeed(): string {
+  return Array.from(crypto.getRandomValues(new Uint8Array(32)))
+    .map((x) => x.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/pages/new-game.tsx
+++ b/src/pages/new-game.tsx
@@ -10,7 +10,7 @@ import useLocalStorage from "~/hooks/localStorage";
 import { newGame } from "~/lib/actions";
 import { logEvent } from "~/lib/analytics";
 import { updateGame } from "~/lib/firebase";
-import { readableUniqueId } from "~/lib/id";
+import { generateShuffleSeed, readableUniqueId } from "~/lib/id";
 import { GameMode, GameVariant, IGameHintsLevel } from "~/lib/state";
 
 const PlayerCounts = [2, 3, 4, 5];
@@ -67,7 +67,7 @@ export default function NewGame() {
    * Initialise seed on first render
    */
   useEffect(() => {
-    setSeed(`${Math.round(Math.random() * 10000)}`);
+    setSeed(generateShuffleSeed());
   }, []);
 
   async function onCreateGame() {


### PR DESCRIPTION
Currently, the deck is shuffled based on a seed chosen at random between 0 and 10000. This means that there are only about 10000 possible deck shuffles, which is quite small; if you play 119 games, you have a greater than 50% chance of seeing the same shuffle twice at some point. This PR adds a lot more entropy to the shuffle seeds so that the chance of seeing the same shuffle seed twice is negligible.

Incidentally, there's a similar problem with the readable game IDs; based on the [unique-names-generator](https://www.npmjs.com/package/unique-names-generator) documentation, there are only about 1400 * 350 * 50 = 24.5 million possible IDs. Starting from an empty database, if 5829 games are created, one of them would likely error out due to a collision, and this will get more and more common as the game database grows indefinitely. This isn't as big a problem as the shuffle seed (if creating a game fails, you could just try again and likely succeed) but it could be a good idea to add more entropy to game IDs as well. (I think this could be done without degrading the UX by using more words in the IDs, but making the words much more common.)