### PR TITLE
Indicate the turn number at the beginning of log messages.

### DIFF
--- a/src/components/logs.tsx
+++ b/src/components/logs.tsx
@@ -31,7 +31,7 @@ export default function Logs(props: Props) {
             const key = game.turnsHistory.length - i;
 
             const messages = game.messages.filter((message) => message.turn === game.turnsHistory.length - i).reverse();
-
+            const turnNumber = game.turnsHistory.length - i;
             return (
               <PoseItem key={key}>
                 {messages.map((message) => {
@@ -41,6 +41,7 @@ export default function Logs(props: Props) {
                   key={key}
                   showDrawn={!interturn && game.players[turn.action.from].id !== selfPlayer?.id}
                   turn={turn}
+                  turnNumber={turnNumber}
                 />
               </PoseItem>
             );

--- a/src/components/turn.tsx
+++ b/src/components/turn.tsx
@@ -11,6 +11,7 @@ interface Props {
   turn: ITurn;
   showDrawn: boolean;
   showPosition?: boolean;
+  turnNumber?: number;
 }
 
 export default function Turn(props: Props) {
@@ -112,8 +113,10 @@ export default function Turn(props: Props) {
 
   return (
     <div className="dib">
+      {props.turnNumber ? <Txt className="di gray">{props.turnNumber})&nbsp;</Txt> : ""}
       <Txt className="di">
-        {/* The player action and the card they drawn, if applicable */}- {textualTurn}
+        {/* The player action and the card they drawn, if applicable */}
+        {textualTurn}
         {drawnTurn}
       </Txt>
     </div>


### PR DESCRIPTION
The primary motivation in this change is that while playing, we want to make notes about events to refer to later post-game when we review interesting situations.  However, without this, the current turn # is not visible on the main screen.

The actual change is fairly trivial.