### PR TITLE
Fix bug that causes the strike buzzer to play when leaving replay mode.

### DIFF
--- a/src/hooks/sounds.ts
+++ b/src/hooks/sounds.ts
@@ -10,8 +10,8 @@ export function useSoundEffects() {
   const game = useGame();
   const replay = useReplay();
   const selfPlayer = useSelfPlayer();
-
   const isReplaying = replay.cursor !== null;
+  const previousTurnsPlayed = usePrevious((game.originalGame || game).turnsHistory.length);
 
   /**
    * Handle notification sounds.
@@ -51,6 +51,7 @@ export function useSoundEffects() {
   useEffect(() => {
     if (isReplaying) return;
     if (previousStrikeCount === undefined) return;
+    if (game.turnsHistory.length <= previousTurnsPlayed) return;
 
     const timeout = setTimeout(() => {
       playSound(`/static/sounds/strike.mp3`);


### PR DESCRIPTION
How to recreate the bug.   

1.  Play a game that has one strike
2. Enter rewind mode
3. Push the cursor to a point before the one strike
4. Click "Back to game"

I think the problem probably manifests for most if not all of the sounds effects in sounds.tsx, it's just that most of the sounds are pretty quiet and thus not as jarring as the strike buzzer.