### PR TITLE
[WIP] Make Tutorial translatable

### DIFF
--- a/src/lib/tutorial.tsx
+++ b/src/lib/tutorial.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from "react";
+import { Trans, useTranslation } from "react-i18next";
 import Card, { CardSize, ICardContext } from "~/components/card";
 import Vignette from "~/components/vignette";
 import { useGame } from "~/hooks/game";
@@ -62,121 +63,131 @@ export function isTutorialAction(game: IGameState, tutAction: IAction, action: I
 export function useTutorialAction() {
   const game = useGame();
   const currentTurn = Math.round(game.turnsHistory.length / game.options.playersCount);
+  const { t } = useTranslation();
+
+  const tutorialActions: TutorialAction[] = [
+    {
+      action: { action: "hint", type: "number", value: 1, to: 2, from: 0 },
+      content: (
+        <Trans i18nKey="tutorialActions.beginning.content">
+          At the beginning of the game, you know nothing about your hand, so discarding or playing a card could be
+          dangerous. <br />
+          It is safer to give a hint. Adam here has two playable cards:
+          {card(IColor.YELLOW, 1)}
+          and
+          {card(IColor.BLUE, 1)}.<br />
+          Let's tell him by hinting him 1s.
+        </Trans>
+      ),
+      todo: (
+        <Trans i18nKey="tutorialActions.beginning.todo">
+          Tap Adam's game, select {vignette("number", 1)}, then click "Hint"
+        </Trans>
+      ),
+    },
+    {
+      action: { action: "play", cardIndex: 1, from: 0 },
+      content: (
+        <Trans i18nKey="tutorialActions.playFirstRed.content">
+          Nice! Adam played his first card from the hint you gave him.
+          <br />
+          Jane also gave you a {vignette("color", IColor.RED)} hint on 2 cards. It might mean those cards are
+          interesting to play right now.
+          <br />
+          <span className="txt-blue db mt1">Convention: Left-most principle</span>
+          When receiving a "play" hint on multiple cards, let's assume it the leftmost one is the interesting one.
+        </Trans>
+      ),
+      todo: t("tutorialActions.playFirstRed.todo"),
+    },
+    {
+      action: { action: "play", cardIndex: 2, from: 0 },
+      content: (
+        <Trans i18nKey="tutorialActions.playSecondRed.content">
+          All right. We still know that our third card is red.
+          <br />
+          <span className="txt-blue db mt1">Convention: optimism</span>
+          When receiving a hint on multiple cards, let's assume that they're all playable, one by one, from left to
+          right. If it's not the case, let's trust our team to give us a "stop" hint to prevent us from making a
+          mistake.
+          <br />
+          Let's be optimisic and assume that our third card is {card(IColor.RED, 2)}
+        </Trans>
+      ),
+      todo: t("tutorialActions.playSecondRed.todo", "Select your game, then play your third card."),
+    },
+    {
+      action: { action: "hint", type: "color", value: IColor.BLUE, to: 1, from: 0 },
+      content: (
+        <Trans i18nKey="tutorialActions.hint.content">
+          We don't know anything about our hand and we still have 4 hints {token("hints")} left to give hints.
+          <br />
+          <br />
+          Adam know that his 3rd card is blue. Maybe that if you hint Jane about her {card(IColor.BLUE, 3)} and she
+          plays it, Adam will understand he can play his {card(IColor.BLUE, 4)}
+        </Trans>
+      ),
+      todo: (
+        <Trans i18nKey="tutorialActions.hint.todo">
+          Tap Jane's game and hint her {vignette("color", IColor.BLUE)}s
+        </Trans>
+      ),
+    },
+    {
+      action: { action: "play", cardIndex: 3, from: 0 },
+      content: (
+        <Trans i18nKey="tutorialActions.interpret.content">
+          Hmmm, looks like Adam didn't understand you. No big deal though, no mistakes have been made.
+          <br />
+          We received a {vignette("color", IColor.YELLOW)} hint. Can you guess what it means?
+        </Trans>
+      ),
+      todo: t("tutorialActions.interpret.todo", "Interpret the hint you just received 😉"),
+    },
+    {
+      action: { action: "discard", cardIndex: 4, from: 0 },
+      content: (
+        <Trans i18nKey="tutorialActions.discard.content">
+          Things are progressing nicely, you already played 8 cards. However your team is running low on hints and
+          you'll soon get stuck. In order to gain more hints, you'll have to start discarding cards.
+          <br />
+          <span className="txt-blue db mt1">Convention: right-most discard</span>
+          Discarding a card can be risky since you could accidently throw away an important card and get stuck in the
+          game. Always discard your unknown right-most card as it's the oldest one. Like so, if it was dangerous to
+          discard, your teammates would have had time to let you know.
+          <br />
+        </Trans>
+      ),
+      todo: t("tutorialActions.discard.todo", "Discard your right-most card"),
+    },
+    {
+      action: { action: "play", cardIndex: 0, from: 0 },
+      content: (
+        <Trans i18nKey="tutorialActions.play.content">
+          Looks like your teammates are a bit wasteful. You're out of hints. They'll probably have to discard next turn.
+          <br />
+        </Trans>
+      ),
+      todo: t("tutorialActions.play.todo", "Play your first card"),
+    },
+    {
+      action: { action: "hint", type: "number", value: 5, to: 1, from: 0 },
+      content: (
+        <Trans i18nKey="tutorialActions.save.content">
+          😅 Adam just discarded {card(IColor.GREEN, 5)}. There's only one {vignette("number", 5)} for each color in the
+          deck so it should never be discarded!
+          <br />
+          <br />
+          It might have been predicted using the <span className="txt-blue">right-most discard</span> convention. Adam
+          had info about his latest card, so he chose to discard {card(IColor.GREEN, 5)} instead.
+          <br />
+          <br />
+          Always be mindful of what your teammates are likely to do next!
+        </Trans>
+      ),
+      todo: <Trans i18nKey="tutorialActions.save.todo">Tell Jane about her {card(IColor.YELLOW, 5)}</Trans>,
+    },
+  ];
 
   return tutorialActions[currentTurn];
 }
-
-export const tutorialActions: TutorialAction[] = [
-  {
-    action: { action: "hint", type: "number", value: 1, to: 2, from: 0 },
-    content: (
-      <>
-        At the beginning of the game, you know nothing about your hand, so discarding or playing a card could be
-        dangerous. <br />
-        It is safer to give a hint. Adam here has two playable cards:
-        {card(IColor.YELLOW, 1)}
-        and
-        {card(IColor.BLUE, 1)}.<br />
-        Let's tell him by hinting him 1s.
-      </>
-    ),
-    todo: <>Tap Adam's game, select {vignette("number", 1)}, then click "Hint"</>,
-  },
-  {
-    action: { action: "play", cardIndex: 1, from: 0 },
-    content: (
-      <>
-        Nice! Adam played his first card from the hint you gave him.
-        <br />
-        Jane also gave you a {vignette("color", IColor.RED)} hint on 2 cards. It might mean those cards are interesting
-        to play right now.
-        <br />
-        <span className="txt-blue db mt1">Convention: Left-most principle</span>
-        When receiving a "play" hint on multiple cards, let's assume it the leftmost one is the interesting one.
-      </>
-    ),
-    todo: <>Select your game, then play your second card.</>,
-  },
-  {
-    action: { action: "play", cardIndex: 2, from: 0 },
-    content: (
-      <>
-        All right. We still know that our third card is red.
-        <br />
-        <span className="txt-blue db mt1">Convention: optimism</span>
-        When receiving a hint on multiple cards, let's assume that they're all playable, one by one, from left to right.
-        If it's not the case, let's trust our team to give us a "stop" hint to prevent us from making a mistake.
-        <br />
-        Let's be optimisic and assume that our third card is {card(IColor.RED, 2)}
-      </>
-    ),
-    todo: <>Select your game, then play your third card.</>,
-  },
-  {
-    action: { action: "hint", type: "color", value: IColor.BLUE, to: 1, from: 0 },
-    content: (
-      <>
-        We don't know anything about our hand and we still have 4 hints {token("hints")} left to give hints.
-        <br />
-        <br />
-        Adam know that his 3rd card is blue. Maybe that if you hint Jane about her {card(IColor.BLUE, 3)} and she plays
-        it, Adam will understand he can play his {card(IColor.BLUE, 4)}
-      </>
-    ),
-    todo: <>Tap Jane's game and hint her {vignette("color", IColor.BLUE)}s</>,
-  },
-  {
-    action: { action: "play", cardIndex: 3, from: 0 },
-    content: (
-      <>
-        Hmmm, looks like Adam didn't understand you. No big deal though, no mistakes have been made.
-        <br />
-        We received a {vignette("color", IColor.YELLOW)} hint. Can you guess what it means?
-      </>
-    ),
-    todo: <>Interpret the hint you just received 😉</>,
-  },
-  {
-    action: { action: "discard", cardIndex: 4, from: 0 },
-    content: (
-      <>
-        Things are progressing nicely, you already played 8 cards. However your team is running low on hints and you'll
-        soon get stuck. In order to gain more hints, you'll have to start discarding cards.
-        <br />
-        <span className="txt-blue db mt1">Convention: right-most discard</span>
-        Discarding a card can be risky since you could accidently throw away an important card and get stuck in the
-        game. Always discard your unknown right-most card as it's the oldest one. Like so, if it was dangerous to
-        discard, your teammates would have had time to let you know.
-        <br />
-      </>
-    ),
-    todo: <>Discard your right-most card</>,
-  },
-  {
-    action: { action: "play", cardIndex: 0, from: 0 },
-    content: (
-      <>
-        Looks like your teammates are a bit wasteful. You're out of hints. They'll probably have to discard next turn.
-        <br />
-      </>
-    ),
-    todo: <>Play your first card</>,
-  },
-  {
-    action: { action: "hint", type: "number", value: 5, to: 1, from: 0 },
-    content: (
-      <>
-        😅 Adam just discarded {card(IColor.GREEN, 5)}. There's only one {vignette("number", 5)} for each color in the
-        deck so it should never be discarded!
-        <br />
-        <br />
-        It might have been predicted using the <span className="txt-blue">right-most discard</span> convention. Adam had
-        info about his latest card, so he chose to discard {card(IColor.GREEN, 5)} instead.
-        <br />
-        <br />
-        Always be mindful of what your teammates are likely to do next!
-      </>
-    ),
-    todo: <>Tell Jane about her {card(IColor.YELLOW, 5)}</>,
-  },
-];

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -315,4 +315,16 @@ export const en = {
       4: "The conventions mentioned afterwards are not part of the official rules, but rather a system some players created to be more efficient. If you'd like to discover those by yourself, you can leave this tutorial right now and jump right into a game.",
     },
   },
+  tutorialActions: {
+    beginning: {
+      cotent:
+        "At the beginning of the game, you know nothing about your hand, so discarding or playing a card could be dangerous.\nIt is safer to give a hint. Adam here has two playable cards:<3/>and<5/>.\nLet's tell him by hinting him 1s.",
+      todo: 'Tap Adam\'s game, select <1/>, then click "Hint"',
+    },
+    playFirstRed: {
+      cotent:
+        'Nice! Adam played his first card from the hint you gave him.\nJane also gave you a <3/> hint on 2 cards. It might mean those cards are interesting to play right now.\n<6>Convention: Left-most principle</6>When receiving a "play" hint on multiple cards, let\'s assume it the leftmost one is the interesting one.',
+      todo: "Select your game, then play your second card.",
+    },
+  },
 };


### PR DESCRIPTION
Hi team, I want to add Simplified Chinese translation to the game. While I translate strings, I found the tutorial is not currently translatable, so I want to add this feature first.

I have used i18next `Trans` and `t`, added i18n keys to all elements and created an example structure in en.ts. Please let me know if this approach seems right.