### PR TITLE
Clear local state that is not relevant after commit

### DIFF
--- a/src/components/playerGame.tsx
+++ b/src/components/playerGame.tsx
@@ -363,13 +363,15 @@ export default function PlayerGame(props: Props) {
                       }
                       id={action}
                       text={t(action)}
-                      onClick={() =>
+                      onClick={() => {
                         onCommitAction({
                           action: action as "discard" | "play",
                           from: selfPlayer.index,
                           cardIndex: selectedCard,
-                        })
-                      }
+                        });
+                        setPendingHint({ value: null, type: null } as IHintAction);
+                        selectCard(null);
+                      }}
                     />
                   ))}
                 </div>
@@ -414,14 +416,16 @@ export default function PlayerGame(props: Props) {
                 }
                 id="give-hint"
                 text={t("hint")}
-                onClick={() =>
+                onClick={() => {
                   onCommitAction({
                     action: "hint",
                     from: currentPlayer.index,
                     to: player.index,
                     ...pendingHint,
-                  })
-                }
+                  });
+                  setPendingHint({ value: null, type: null } as IHintAction);
+                  selectCard(null);
+                }}
               />
             </div>
           </div>


### PR DESCRIPTION
The PlayerGame has some minor state (selected card (for the self-player), and pendingHint (vignette) for all other players.  Some players I have played with have found it mildly confusing (including me, from time-to-time). that this state is carrying over from action to action.

I've also had times where I go to give a hint to a player, think I've "set" the hint and click HINT, but the setting. part didn't take, and so the left-over state was used for the Hint.

This addresses that, so that the state is cleared after relevant actions.