### PR TITLE
Add New Game button to menu

### DIFF
--- a/src/components/menuArea.tsx
+++ b/src/components/menuArea.tsx
@@ -12,10 +12,11 @@ import { UserPreferences, useUserPreferences } from "~/hooks/userPreferences";
 
 interface Props {
   onCloseArea: () => void;
+  onRestartGame: ({ abandoned }: { abandoned: boolean }) => Promise<void>;
 }
 
 export default function MenuArea(props: Props) {
-  const { onCloseArea } = props;
+  const { onCloseArea, onRestartGame } = props;
 
   const [showRules, setShowRules] = useState(false);
   const { reset } = useContext(TutorialContext);
@@ -33,6 +34,11 @@ export default function MenuArea(props: Props) {
 
   function onTutorialClick() {
     reset();
+    onCloseArea();
+  }
+
+  async function onRestartClick() {
+    onRestartGame({ abandoned: true });
     onCloseArea();
   }
 
@@ -69,6 +75,7 @@ export default function MenuArea(props: Props) {
               text={t("rules")}
               onClick={() => setShowRules(true)}
             />
+            <Button className="mb3 w-100" size={ButtonSize.MEDIUM} text={t("newGame")} onClick={onRestartClick} />
           </div>
         )}
 


### PR DESCRIPTION
## Description

Adds the ability to abandon a game early by clicking the "New Game" button in the menu at any point during the game. 
This fast forwards you to the "game over" menu but retains the history of the abandoned game. 

### Notes
- I was a little constrained by translations here, I'm not sure what the philosophy is on adding new untranslated text.  "New Game" is not the most accurate wording but there's no existing translation for "Abandon Game". There also aren't any translations for words I could use in a confirmation dialog so I wasn't able to add that either
- Whether or not one person should be able to end the game just like that without discussion is questionable, but since it is a fully co-op game, ending it doesn't erase any history, and they could achieve the same result by just closing the browser, I figured it was reasonable

## Screenshots
![image](https://github.com/bstnfrmry/hanabi/assets/71364792/67c64729-194d-42ab-bb2e-0016d75d8f66)
![image](https://github.com/bstnfrmry/hanabi/assets/71364792/32043d56-469a-4380-8b59-76e9e8f2efa2)
![image](https://github.com/bstnfrmry/hanabi/assets/71364792/bde120c9-762c-48bf-9162-afae112d5cd8)
