### PR TITLE
Adjust SVG image handling

### DIFF
--- a/src/components/ui/svgImage.tsx
+++ b/src/components/ui/svgImage.tsx
@@ -1,20 +1,21 @@
 import Image from "next/legacy/image";
 import React from "react";
-interface ImportedSvg {
+
+interface SizedSvg {
   src: string;
   width: number;
   height: number;
 }
-
+interface DefaultWrappedSvg {
+  default: SizedSvg;
+}
+type ImportedSvg = DefaultWrappedSvg | SizedSvg;
+function isDefaultWrappedSvg(svg: ImportedSvg): svg is DefaultWrappedSvg {
+  return "default" in svg;
+}
 export function SvgImage(props: { svg: ImportedSvg; alt?: string; width?: number; height?: number }) {
-  const svg = props.svg;
+  const svg: SizedSvg = isDefaultWrappedSvg(props.svg) ? props.svg.default : props.svg;
   const location = window.location;
-  return (
-    <Image
-      alt={props.alt}
-      height={props.height || svg.height}
-      src={location.protocol + "//" + location.host + svg.src.substr(1)}
-      width={props.width || svg.width}
-    />
-  );
+  const svgUrl = location.protocol + "//" + location.host + svg.src.substring(1);
+  return <Image alt={props.alt} height={props.height || svg.height} src={svgUrl} width={props.width || svg.width} />;
 }


### PR DESCRIPTION
Something odd is going on with respect to require('..../Foo.svg') that seems to manifest differently on Chrome vs Firefox.  This adapts to that in an encapsulated manner.  Switching away from legacy/Image might improve things or might not.