### PR TITLE
Eliminate rc-slider handling keyboard events

### DIFF
--- a/src/components/replayViewer.tsx
+++ b/src/components/replayViewer.tsx
@@ -96,6 +96,7 @@ export default function ReplayViewer(props: Props) {
         <Slider
           className="ml3 nt1"
           dotStyle={SliderStyle.DOT}
+          keyboard={false}
           marks={marks}
           max={maxTurns}
           min={0}
@@ -106,7 +107,6 @@ export default function ReplayViewer(props: Props) {
           }}
           value={replay.cursor}
           onChange={replayChange}
-          onChangeComplete={replayChange}
         />
         <Button
           void

--- a/src/components/replayViewer.tsx
+++ b/src/components/replayViewer.tsx
@@ -50,18 +50,8 @@ export default function ReplayViewer(props: Props) {
   const { onReplayCursorChange, onStopReplay } = props;
   const game = useGame();
   const selfPlayer = useSelfPlayer(game);
-  const [comment, setComment] = useState<IReviewComment | undefined>(
-    findComment(game, selfPlayer?.id, game.turnsHistory.length)
-  );
   const replay = useReplay();
-  const replayChange = useCallback(
-    (cursor: number) => {
-      onReplayCursorChange(cursor);
-      setComment(findComment(game, selfPlayer?.id, cursor));
-    },
-    [game, selfPlayer, onReplayCursorChange]
-  );
-
+  const comment = findComment(game, selfPlayer.id, replay.cursor);
   const maxTurns = game.originalGame.turnsHistory.length;
 
   const marks: Record<string | number, React.ReactNode | MarkObj> = {};
@@ -91,7 +81,7 @@ export default function ReplayViewer(props: Props) {
           disabled={replay.cursor === 0}
           size={ButtonSize.TINY}
           text="<"
-          onClick={() => replayChange(replay.cursor - 1)}
+          onClick={() => onReplayCursorChange(replay.cursor - 1)}
         />
         <Slider
           className="ml3 nt1"
@@ -106,7 +96,7 @@ export default function ReplayViewer(props: Props) {
             handle: SliderStyle.HANDLE,
           }}
           value={replay.cursor}
-          onChange={replayChange}
+          onChange={onReplayCursorChange}
         />
         <Button
           void
@@ -114,7 +104,7 @@ export default function ReplayViewer(props: Props) {
           disabled={replay.cursor === maxTurns}
           size={ButtonSize.TINY}
           text=">"
-          onClick={() => replayChange(replay.cursor + 1)}
+          onClick={() => onReplayCursorChange(replay.cursor + 1)}
         />
         <Button void className="ml3 pointer:hover" size={ButtonSize.TINY} text="&times;" onClick={onStopReplay} />
       </div>


### PR DESCRIPTION
There was bug reported that sometimes you'd get double-movements for arrow.  Turns out it was after clicking on the slider, the slider _and_ the Hanab keyboard handler were both processing each keydown.  Disabled keyboard handling on the slider, and stopped listening to onChangeComplete() which fires from the slider even if keyboard handling is disabled.