### PR TITLE
Cosmetic UI fixes

### DIFF
--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -225,7 +225,7 @@ export default function Card(props: Props) {
           e.stopPropagation();
           return;
         }
-        onClick(e);
+        onClick?.(e);
       }}
       {...longPressProps}
     >

--- a/src/components/lobby.tsx
+++ b/src/components/lobby.tsx
@@ -185,7 +185,7 @@ export default function Lobby(props: Props) {
               </a>
             </div>
             <input ref={inputRef} readOnly className="fixed top--2 left--2" type="text" value={shareLink} />
-            <Button text={t("copy")} onClick={copy} />
+            <Button outlined text={t("copy")} onClick={copy} />
           </div>
         )}
       </div>

--- a/src/components/menuArea.tsx
+++ b/src/components/menuArea.tsx
@@ -53,7 +53,7 @@ export default function MenuArea(props: Props) {
 
   return (
     <Modal isOpen onRequestClose={() => onCloseArea()}>
-      <div className="flex flex-column justify-center items-center w-100 h-100 pa2 z-10">
+      <div className={`flex flex-column justify-center items-center w-100 h-100 z-10 ${showRules ? "" : "pa2"}`}>
         {!showRules && (
           <div className="flex flex-column justify-center items-center">
             <Txt className="ttu txt-yellow mb4 mb5-l" size={TxtSize.MEDIUM} value={t("hanab")} />

--- a/src/components/turn.tsx
+++ b/src/components/turn.tsx
@@ -139,7 +139,13 @@ export default function Turn(props: Props) {
 
   return (
     <div className="dib">
-      {props.turnNumber ? <Txt className={classnames("di gray")} size={TxtSize.XSMALL}>{props.turnNumber}</Txt> : ""}
+      {props.turnNumber ? (
+        <Txt className={classnames("di gray")} size={TxtSize.XSMALL}>
+          {props.turnNumber}
+        </Txt>
+      ) : (
+        ""
+      )}
       <span>&nbsp;</span>
       <Txt className="di">
         {/* The player action and the card they have drawn, if applicable */}

--- a/src/components/turn.tsx
+++ b/src/components/turn.tsx
@@ -139,7 +139,7 @@ export default function Turn(props: Props) {
 
   return (
     <div className="dib">
-      {props.turnNumber ? <Txt className={classnames("di gray")}>{props.turnNumber}</Txt> : ""}
+      {props.turnNumber ? <Txt className={classnames("di gray")} size={TxtSize.XSMALL}>{props.turnNumber}</Txt> : ""}
       <span>&nbsp;</span>
       <Txt className="di">
         {/* The player action and the card they have drawn, if applicable */}
@@ -167,12 +167,12 @@ const HintValue = ({ action }: { action: IHintAction }) => (
 const CardPosition = ({ action }: { action: IDiscardAction | IPlayAction | IHintAction }) =>
   action.action === "hint" ? (
     <Txt
-      className="lavender mr1"
+      className="gray mr1"
       size={TxtSize.XSMALL}
       value={`${(action?.cardsIndex ?? []).map((index) => PositionMap[index]).join(", ")}`}
     />
   ) : (
-    <Txt className="lavender mr1" size={TxtSize.XSMALL} value={`${PositionMap[action.cardIndex]}`} />
+    <Txt className="gray mr1" size={TxtSize.XSMALL} value={`${PositionMap[action.cardIndex]}`} />
   );
 
 const DrawnCard = ({ card }: { card: ICard }) => (

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -38,7 +38,7 @@ export function Modal(props: Props) {
       }}
     >
       <div className="bg-main-dark">
-        {onRequestClose && <Button void className="absolute right-1 top-1" text="&times;" onClick={onRequestClose} />}
+        {onRequestClose && <Button void className="absolute right-1 top-1 z-5" text="&times;" onClick={onRequestClose} />}
 
         {children}
       </div>

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -38,7 +38,9 @@ export function Modal(props: Props) {
       }}
     >
       <div className="bg-main-dark">
-        {onRequestClose && <Button void className="absolute right-1 top-1 z-5" text="&times;" onClick={onRequestClose} />}
+        {onRequestClose && (
+          <Button void className="absolute right-1 top-1 z-5" text="&times;" onClick={onRequestClose} />
+        )}
 
         {children}
       </div>


### PR DESCRIPTION
## Summary
- Grey card position labels, smaller turn numbers
- Fix card onClick crash, modal close button z-index
- Outlined lobby copy button, less padding on rules modal

## Test plan
- [ ] Game log renders correctly
- [ ] Rules modal and lobby work as expected
- [ ] Test on mobile, tablet, desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)