### PR TITLE
Keep card deck open across turns

### DIFF
--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -62,10 +62,16 @@ export function Game(props: Props) {
   useSoundEffects();
 
   /**
-   * Resets the selected area when a player plays.
+   * Resets the selected area when a player plays,
+   * unless the self player's own cards are currently expanded.
    */
   useEffect(() => {
-    selectArea({ id: "logs", type: ActionAreaType.LOGS });
+    selectArea((current) => {
+      if (current.type === ActionAreaType.SELF_PLAYER) {
+        return { ...current, id: `game-${current.player.id}`, cardIndex: undefined };
+      }
+      return { id: "logs", type: ActionAreaType.LOGS };
+    });
   }, [game.turnsHistory.length]);
 
   /**
@@ -85,21 +91,29 @@ export function Game(props: Props) {
   useEffect(() => {
     if (!game.synced) return;
     if (game.status !== IGameStatus.ONGOING) return;
-    if (!selfPlayer || selfPlayer.index) return;
+    if (!selfPlayer) return;
     if (!currentPlayer.bot) return;
 
-    if (game.options.botsWait === 0) {
-      updateGame(play(game)).catch(logFailedPromise);
-      return;
+    try {
+      if (game.options.botsWait === 0) {
+        updateGame(play(game)).catch(logFailedPromise);
+        return;
+      }
+
+      setReaction(game, currentPlayer, "🧠").catch(logFailedPromise);
+      const timeout = setTimeout(() => {
+        try {
+          updateGame(play(game)).catch(logFailedPromise);
+          game.options.botsWait && setReaction(game, currentPlayer, null);
+        } catch (e) {
+          console.error(`[Bot] Error during play:`, e);
+        }
+      }, game.options.botsWait);
+
+      return () => clearTimeout(timeout);
+    } catch (e) {
+      console.error(`[Bot] Error during play:`, e);
     }
-
-    setReaction(game, currentPlayer, "🧠").catch(logFailedPromise);
-    const timeout = setTimeout(() => {
-      updateGame(play(game)).catch(logFailedPromise);
-      game.options.botsWait && setReaction(game, currentPlayer, null);
-    }, game.options.botsWait);
-
-    return () => clearTimeout(timeout);
   }, [game.currentPlayer, game.status, game.synced, game, currentPlayer, selfPlayer]);
 
   /**

--- a/src/components/playerGame.tsx
+++ b/src/components/playerGame.tsx
@@ -421,13 +421,14 @@ export default function PlayerGame(props: Props) {
                       id={action}
                       text={t(action)}
                       onClick={() => {
+                        const cardIdx = selectedCard;
                         onCommitAction({
                           action: action as "discard" | "play",
                           from: selfPlayer.index,
-                          cardIndex: selectedCard,
+                          cardIndex: cardIdx,
                         });
                         setPendingHint({ value: null, type: null } as IHintAction);
-                        selectCard(null);
+                        selectCard(cardIdx);
                       }}
                     />
                   ))}


### PR DESCRIPTION
## Summary
- Self player's expanded card deck persists when other players take turns
- Card selection cleared but deck stays open on turn change to avoid double-click
- Same card index re-selected after play/discard for faster consecutive actions
- Fix bot not playing when human is not player index 0

## Test plan
- [ ] Open own cards, verify they stay open when AI plays
- [ ] Verify single click selects a card (no double-click needed)
- [ ] Play/discard a card, verify same position stays selected
- [ ] Test bot play in 2+ player games

🤖 Generated with [Claude Code](https://claude.com/claude-code)