### PR TITLE
UI polish: fix stray semicolon, copy feedback, and cleanup

### DIFF
--- a/src/components/lobby.tsx
+++ b/src/components/lobby.tsx
@@ -62,6 +62,7 @@ export default function Lobby(props: Props) {
   const router = useRouter();
   const [name, setName] = useState("");
   const [bot, setBot] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const gameFull = game.players.length === game.options.playersCount;
   const canJoin = (game.options.gameMode === GameMode.PASS_AND_PLAY || !selfPlayer) && !gameFull;
@@ -72,6 +73,8 @@ export default function Lobby(props: Props) {
   function copy() {
     inputRef.current.select();
     document.execCommand("copy");
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   }
 
   useEffect(() => {
@@ -93,6 +96,14 @@ export default function Lobby(props: Props) {
 
   return (
     <div className="flex items-center justify-center h-100 w-100 pa2">
+      {copied && (
+        <div
+          className="fixed z-999 bg-white black ph3 pv2 br2 shadow-2 f6 fw5"
+          style={{ top: "1rem", left: "50%", transform: "translateX(-50%)" }}
+        >
+          {t("copied")}
+        </div>
+      )}
       <Meta />
       <div className="flex flex-column pa2 w-100 h-100">
         <div className="mb3 ttu flex items-center">

--- a/src/components/playerGame.tsx
+++ b/src/components/playerGame.tsx
@@ -319,14 +319,6 @@ export default function PlayerGame(props: Props) {
           )}
           {!displayStats && (
             <div className="relative flex items-center justify-end flex-grow-1 dib">
-              {selected && (
-                <Txt
-                  className="lavender absolute top--1 right-2 dib"
-                  size={TxtSize.XSMALL}
-                  style={{ marginTop: "-1px" }}
-                  value="⟶"
-                />
-              )}
 
               {/* When game has ended (even in replay mode)
               Enable user to view their game */}

--- a/src/components/playerGame.tsx
+++ b/src/components/playerGame.tsx
@@ -319,7 +319,6 @@ export default function PlayerGame(props: Props) {
           )}
           {!displayStats && (
             <div className="relative flex items-center justify-end flex-grow-1 dib">
-
               {/* When game has ended (even in replay mode)
               Enable user to view their game */}
               {(game.endedAt || game.originalGame?.endedAt) && player === selfPlayer && (

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -22,6 +22,7 @@ export const de = {
   autoplay: "Autoplay",
   shareGame: "Dieses Spiel teilen",
   copy: "Kopieren",
+  copied: "Kopiert!",
   waitForOthers: "Warte auf andere oder ",
   gameStarted: "Spiel gestartet!",
   gameStarts: "Spiel startet!",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -28,6 +28,7 @@ export const en = {
   autoplay: "Autoplay",
   shareGame: "Share this game",
   copy: "Copy",
+  copied: "Copied!",
   waitForOthers: "Wait for others, or ",
   gameStarted: "Game started!",
   gameStarts: "Game starts!",

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -22,6 +22,7 @@ export const es = {
   autoplay: "Autoplay",
   shareGame: "Comparte este juego",
   copy: "Copiar",
+  copied: "¡Copiado!",
   waitForOthers: "Puedes esperar a los demás o ",
   gameStarted: "¡Comenzó el juego!",
   gameStarts: "¡Comienza el juego!",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -22,6 +22,7 @@ export const fr = {
   autoplay: "Autoplay",
   shareGame: "Partager cette partie",
   copy: "Copier",
+  copied: "Copié !",
   waitForOthers: "Tu peux attendre les autres ou ",
   gameStarted: "Début de la partie",
   gameStarts: "Début de la partie",

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -22,6 +22,7 @@ export const it = {
   autoplay: "Autoplay",
   shareGame: "Condividi questa partita",
   copy: "Copia",
+  copied: "Copiato!",
   waitForOthers: "Aspetta altri giocatori, o ",
   gameStarted: "Partita iniziata!",
   gameStarts: "La partita inizia!",

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -21,6 +21,7 @@ export const nl = {
   autoplay: "Autoplay",
   shareGame: "Deel dit spel",
   copy: "Kopiëren",
+  copied: "Gekopieerd!",
   waitForOthers: "Wachten op andere spelers, of ",
   gameStarted: "Spel gestart!",
   gameStarts: "Spel start!",

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -22,6 +22,7 @@ export const pt = {
   autoplay: "Autoplay",
   shareGame: "Compartilhe esse jogo",
   copy: "Copiar",
+  copied: "Copiado!",
   waitForOthers: "Espere pelos outros, ou ",
   gameStarted: "Jogo começou!",
   gameStarts: "Jogo começa!",

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -27,6 +27,7 @@ export const ru = {
   autoplay: "Авто-игра",
   shareGame: "Поделиться этой игрой",
   copy: "Копировать",
+  copied: "Скопировано!",
   waitForOthers: "Ждать остальных или ",
   gameStarted: "Игра началась!",
   gameStarts: "Игра начинается!",

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -23,6 +23,7 @@ export const sk = {
   autoplay: "Automatické prehrávanie",
   shareGame: "Zdieľať túto hru",
   copy: "Kopírovať",
+  copied: "Skopírované!",
   waitForOthers: "Čakať na ostatných alebo ",
   gameStarted: "Hra začala!",
   gameStarts: "Hra sa začína!",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -23,6 +23,7 @@ export const zh = {
   autoplay: "自动出牌",
   shareGame: "分享房间",
   copy: "复制",
+  copied: "已复制！",
   waitForOthers: "等待其它玩家，或者",
   gameStarted: "游戏已开始！",
   gameStarts: "游戏开始！",

--- a/src/pages/[gameId]/summary.tsx
+++ b/src/pages/[gameId]/summary.tsx
@@ -77,11 +77,17 @@ function ShuffleSeed({ seed, onCopy }: { seed: string; onCopy: () => void }) {
   return (
     <Txt className="mt2 lavender flex items-center" size={TxtSize.MEDIUM}>
       Shuffle: {seed}
-      <button
-        className="ml2 pointer bg-transparent bn lavender o-70 glow"
-        onClick={onCopy}
-      >
-        <svg fill="none" height="16" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="16">
+      <button className="ml2 pointer bg-transparent bn lavender o-70 glow" onClick={onCopy}>
+        <svg
+          fill="none"
+          height="16"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width="16"
+        >
           <rect height="13" rx="2" ry="2" width="13" x="9" y="9" />
           <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
         </svg>

--- a/src/pages/[gameId]/summary.tsx
+++ b/src/pages/[gameId]/summary.tsx
@@ -1,7 +1,7 @@
 import classnames from "classnames";
 import moment from "moment";
 import { useRouter } from "next/router";
-import React, { ReactNode, useCallback, useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import shortid from "shortid";
 import GameActionsStats from "~/components/gameActionsStats";
@@ -60,25 +60,32 @@ interface Props {
   game: IGameState;
 }
 
+function CopiedToast({ visible, label }: { visible: boolean; label: string }) {
+  if (!visible) return null;
+
+  return (
+    <div
+      className="fixed z-999 bg-white black ph3 pv2 br2 shadow-2 f6 fw5"
+      style={{ top: "1rem", left: "50%", transform: "translateX(-50%)" }}
+    >
+      {label}
+    </div>
+  );
+}
+
 function ShuffleSeed({ seed, onCopy }: { seed: string; onCopy: () => void }) {
   return (
     <Txt className="mt2 lavender flex items-center" size={TxtSize.MEDIUM}>
       Shuffle: {seed}
-      <svg
-        className="ml2 pointer"
-        fill="none"
-        height="16"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        viewBox="0 0 24 24"
-        width="16"
+      <button
+        className="ml2 pointer bg-transparent bn lavender o-70 glow"
         onClick={onCopy}
       >
-        <rect height="13" rx="2" ry="2" width="13" x="9" y="9" />
-        <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-      </svg>
+        <svg fill="none" height="16" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="16">
+          <rect height="13" rx="2" ry="2" width="13" x="9" y="9" />
+          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+        </svg>
+      </button>
     </Txt>
   );
 }
@@ -88,6 +95,7 @@ export default function Summary(props: Props) {
 
   const router = useRouter();
   const [game, setGame] = useState<IGameState>(initialGame);
+  const [copied, setCopied] = useState(false);
   const { t } = useTranslation();
 
   /**
@@ -126,9 +134,11 @@ export default function Summary(props: Props) {
     }
   }
 
-  const onCopySeed = useCallback(() => {
+  function onCopySeed() {
     navigator.clipboard.writeText(game.options.seed);
-  }, [game.options.seed]);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
 
   if (!game) {
     return <LoadingScreen />;
@@ -139,6 +149,7 @@ export default function Summary(props: Props) {
 
   return (
     <GameContext.Provider value={game}>
+      <CopiedToast label={t("copied")} visible={copied} />
       <div className="flex flex-column items-center pv4">
         <Button
           void

--- a/src/pages/[gameId]/summary.tsx
+++ b/src/pages/[gameId]/summary.tsx
@@ -135,7 +135,7 @@ export default function Summary(props: Props) {
   }
 
   const gameDuration = game.startedAt && game.endedAt ? formatDuration(game.startedAt, game.endedAt) : null;
-  const shortSeed = game.options.seed ? game.options.seed.slice(0, 4) + "****" + game.options.seed.slice(-4) : "";
+  const shortSeed = game.options.seed ? game.options.seed.slice(0, 4) + "∗∗∗∗" + game.options.seed.slice(-4) : "";
 
   return (
     <GameContext.Provider value={game}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -43,7 +43,7 @@ export default function App(props: AppProps) {
 
   return (
     <Sentry.ErrorBoundary>
-      <Hanab {...props} />;
+      <Hanab {...props} />
     </Sentry.ErrorBoundary>
   );
 }


### PR DESCRIPTION
## Summary
- Remove stray `;` rendered on screen from `_app.tsx`
- Use vertically centered asterisk operator (`∗`) for masked shuffle seed
- Wrap seed copy icon in a `<button>` with hover/focus states
- Add translated "Copied!" toast feedback on seed copy (summary) and link copy (lobby)
- Remove `⟶` card order arrow from player game area

## Test plan
- [ ] Verify no stray `;` on any page
- [ ] Check masked seed displays with centered asterisks
- [ ] Click seed copy button on summary page — confirm toast appears and disappears
- [ ] Click COPY button in lobby — confirm toast appears and disappears
- [ ] Verify card area no longer shows `⟶` arrow
- [ ] Test on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)