### PR TITLE
Fix back button after New game redirect

### DIFF
--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -239,15 +239,28 @@ export function Game(props: Props) {
     location.assign(newUrl);
   }
 
+  // Captured once Firebase has synced the game, so we don't redirect when the
+  // user navigated back to a game whose nextGameId was already set on arrival
+  // — only redirect when the "New game" action happens during this visit.
+  const initialNextGameIdRef = useRef<string | null | undefined>(undefined);
+
   /**
    * Redirect all players to next game
    */
   useEffect(() => {
+    if (!game.synced) return;
+
+    if (initialNextGameIdRef.current === undefined) {
+      initialNextGameIdRef.current = game.nextGameId ?? null;
+      return;
+    }
+
     if (!game.nextGameId) return;
+    if (game.nextGameId === initialNextGameIdRef.current) return;
 
     setDisplayStats(false);
     location.assign(`/${game.nextGameId}`);
-  }, [game.nextGameId]);
+  }, [game.synced, game.nextGameId]);
 
   function onJoinGame(player: Omit<IPlayer, "id">) {
     const newState = joinGame(game, { id: playerId, ...player });
@@ -434,6 +447,12 @@ export function Game(props: Props) {
     await updateGame(nextGame);
     log("Next Game Persisted");
     const updatedGame = { ...finishedGame, nextGameId: nextGame.id };
+    // Pre-set the ref so the redirect effect treats the Firebase echo as
+    // "no change from arrival" and skips location.assign — otherwise the
+    // clicker would navigate twice (router.push below + location.assign from
+    // the effect), leaving a duplicate history entry that breaks the back
+    // button.
+    initialNextGameIdRef.current = nextGame.id;
     await updateGame(updatedGame);
     log("Link to nextGame updated");
     onGameChange(nextGame);

--- a/src/pages/[gameId]/index.tsx
+++ b/src/pages/[gameId]/index.tsx
@@ -41,7 +41,7 @@ export default function Play(props: Props) {
     <TutorialProvider>
       <SessionContext.Provider value={session}>
         <ReplayContext.Provider value={{ cursor: replayCursor, moveCursor: setReplayCursor }}>
-          <GameIndex game={initialGame} host={host}></GameIndex>
+          <GameIndex key={initialGame.id} game={initialGame} host={host}></GameIndex>
         </ReplayContext.Provider>
       </SessionContext.Provider>
     </TutorialProvider>


### PR DESCRIPTION
## Summary

Clicking "New game" redirects all players to the freshly created game.
This PR keeps that redirect but makes the browser back button return to the previous game's end-of-game screen, and forward returns to the new game.

Bug discovered while investigating issue  #339

## The two bugs fixed

1. **Duplicate history entry for the clicker.** `onRestartGame` calls `router.push('/<newGame>')`, and the redirect effect also fires (Firebase echoes the same client's write) and calls `location.assign('/<newGame>')`. That puts two consecutive entries for the same URL in history, so the first back press appeared to do nothing. Pre-setting `initialNextGameIdRef.current` to the new id before the write makes the effect skip the second navigation.

2. **Redirect loop on back navigation.** The effect re-fired when the user returned to the previous game (which now carries a `nextGameId`), forwarding them to the new game again. The effect now waits for `game.synced === true`, captures the initial `nextGameId` once, and only redirects on a genuine transition during the visit.

3. **Stale state on route change.** Next.js reuses the same page component across `/[gameId]` transitions, so `useState(initialGame)` and the Firebase subscription stuck on the old game. Added `key={initialGame.id}` on `GameIndex` to remount cleanly.

## Closes

#339

## Test plan

- [x] Three players in a game. Any player clicks "New game" — all three land on the new game.
- [x] Browser back from the new game → previous game's end-of-game screen (both the clicker and the other players).
- [x] Browser forward → back on the new game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)