### PR TITLE
Add sound effect toggle

### DIFF
--- a/src/components/userPreferencesDialog.tsx
+++ b/src/components/userPreferencesDialog.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export default function UserPreferencesDialog({ onCloseArea, userPreferences, saveUserPreferences }: Props) {
   const { t } = useTranslation();
-  function toggleplaySoundEffects() {
+  function togglePlaySoundEffects() {
     const modifiedPreferences = {
       ...userPreferences,
       playSoundEffects: !userPreferences.playSoundEffects,
@@ -43,7 +43,7 @@ export default function UserPreferencesDialog({ onCloseArea, userPreferences, sa
 
           <div className="mb4 mb5-l">
             <div className="flex flex-row justify-start-l items-center">
-              <Checkbox checked={userPreferences.playSoundEffects} onChange={() => toggleplaySoundEffects()} />
+              <Checkbox checked={userPreferences.playSoundEffects} onChange={() => togglePlaySoundEffects()} />
               &nbsp;
               <Txt value={t("playSoundEffects")} />
             </div>

--- a/src/components/userPreferencesDialog.tsx
+++ b/src/components/userPreferencesDialog.tsx
@@ -13,6 +13,15 @@ interface Props {
 
 export default function UserPreferencesDialog({ onCloseArea, userPreferences, saveUserPreferences }: Props) {
   const { t } = useTranslation();
+  function toggleplaySoundEffects() {
+    const modifiedPreferences = {
+      ...userPreferences,
+      playSoundEffects: !userPreferences.playSoundEffects,
+      soundOnStrike: !userPreferences.playSoundEffects,
+    };
+
+    saveUserPreferences(modifiedPreferences);
+  }
   function toggleSoundOnStrike() {
     const modifiedPreferences = { ...userPreferences, soundOnStrike: !userPreferences.soundOnStrike };
     saveUserPreferences(modifiedPreferences);
@@ -34,7 +43,16 @@ export default function UserPreferencesDialog({ onCloseArea, userPreferences, sa
 
           <div className="mb4 mb5-l">
             <div className="flex flex-row justify-start-l items-center">
-              <Checkbox checked={userPreferences.soundOnStrike} onChange={() => toggleSoundOnStrike()} />
+              <Checkbox checked={userPreferences.playSoundEffects} onChange={() => toggleplaySoundEffects()} />
+              &nbsp;
+              <Txt value={t("playSoundEffects")} />
+            </div>
+            <div className="flex flex-row justify-start-l items-center">
+              <Checkbox
+                checked={userPreferences.soundOnStrike}
+                disabled={!userPreferences.playSoundEffects}
+                onChange={() => toggleSoundOnStrike()}
+              />
               &nbsp;
               <Txt value={t("soundOnStrike")} />
             </div>

--- a/src/hooks/sounds.ts
+++ b/src/hooks/sounds.ts
@@ -38,14 +38,14 @@ export function useSoundEffects() {
    * Handle notification sounds.
    */
   useEffect(() => {
-    if (!selfPlayer?.notified) return;
+    if (!selfPlayer?.notified || !userPreferences.playSoundEffects) return;
 
     playSound(`/static/sounds/bell.mp3`);
     vibrate(200);
     const timeout = setTimeout(() => setNotification(game, selfPlayer, false), 10000);
 
     return () => clearTimeout(timeout);
-  }, [selfPlayer, selfPlayer?.notified, game]);
+  }, [selfPlayer, selfPlayer?.notified, game, userPreferences.playSoundEffects]);
 
   useEffect(() => {
     function determineLastGameEvent(): RecognizedAction {
@@ -81,10 +81,18 @@ export function useSoundEffects() {
 
     if (isReplaying) return;
     if (!turn) return;
+    if (!userPreferences.playSoundEffects) return;
     const namedEvent = determineLastGameEvent();
     if (!namedEvent) return;
     const soundFile = SoundsForAction[namedEvent];
 
     playSound(soundFile);
-  }, [turnsCount, previousTurnsCount, turn, userPreferences.soundOnStrike, isReplaying]);
+  }, [
+    turnsCount,
+    previousTurnsCount,
+    turn,
+    userPreferences.playSoundEffects,
+    userPreferences.soundOnStrike,
+    isReplaying,
+  ]);
 }

--- a/src/hooks/userPreferences.ts
+++ b/src/hooks/userPreferences.ts
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 
 export interface UserPreferences {
+  playSoundEffects?: boolean;
   soundOnStrike?: boolean;
   showFireworksAtGameEnd?: boolean;
   codedHintMarkers?: boolean;
@@ -9,6 +10,7 @@ export interface UserPreferences {
 type ValueAndSetter<T> = [T, (newValue: T) => void];
 
 const DefaultPreferences: UserPreferences = {
+  playSoundEffects: true,
   soundOnStrike: true,
   showFireworksAtGameEnd: true,
   codedHintMarkers: false,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -249,6 +249,7 @@ export const en = {
   learnWhileWaiting: "Learn the basics of Hanab while waiting",
   learnHanabEnglish: "Learn Hanab - ",
   userPreferences: "User Preferences",
+  playSoundEffects: "Play sound effects",
   soundOnStrike: "Play sound when a strike occurs",
   playFireworksAtGameEnd: "Play fireworks at game end",
   learn: {


### PR DESCRIPTION
### Description
Adds an option to user preferences menu to mute all sound effects entirely. 
Toggles the "Play sound effects on strike" option on and off as a sub-option.

### Reasoning
On mobile devices (at least some of them, can't speak for all) there's no easy way to mute sounds, which is super frustrating if you're trying to play music from your phone and the sound effects keep interfering with it.

### Tests
I didn't see any testing framework, and I don't currently have a recording tool that captures internal audio, but here is what I tested and some associated screenshots / screen recordings.
- Checkbox shows correctly in user preferences
- Sound effects play when checkbox is checked
- Sound effects do not play when checkbox is unchecked
- All sound effects except for strike sounds play when sound effects checkbox is checked but strike sound effects checkbox is unchecked
- Checking or unchecking the main sound effects checkbox sets the strike sound effects checkbox accordingly
- Strike sound effects checkbox is disabled if sound effects overall are unchecked (Sorry to the hypothetical people that want to enable only strike sounds and nothing else)
- Reloading the page maintains sound effect settings as expected

<img width="342" height="312" alt="image" src="https://github.com/user-attachments/assets/4875f2c7-204f-4f0c-adc6-4c816ffe9cf2" />

https://github.com/user-attachments/assets/e4b32ed9-2445-4762-ba63-aed85e137479

#### Note: I also did try an alternate ui as below, but it felt a little awkward with the header centered, and I wanted to err on the "smallest change possible" side. 
Can change to it if the alternate is preferred:

<img width="357" height="328" alt="Screenshot 2026-06-06 at 8 53 59 PM" src="https://github.com/user-attachments/assets/24bead89-559b-4be1-88cc-9d1ceb64c83b" />
